### PR TITLE
chore: kensington-admin-client to 0.0.38

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -9,7 +9,7 @@ dependencies:
   version: 2.3.89
 - name: kensington-admin-client
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.36
+  version: 0.0.38
 - name: kensington-admin-server
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.37


### PR DESCRIPTION
chore: Promote kensington-admin-client to version 0.0.38